### PR TITLE
Fix incorrect nationality for Iceland.

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -94,7 +94,7 @@
         "HN": "Honduran",
         "HK": "Hong Kong",
         "HU": "Hungarian",
-        "IS": "Icelander",
+        "IS": "Icelandic",
         "IN": "Indian",
         "ID": "Indonesian",
         "IR": "Iranian",


### PR DESCRIPTION
Replace nationality for Iceland from "Icelander" to "Icelandic"

Issue: #3