### PR TITLE
fix: typo Britannique instead of Britanique

### DIFF
--- a/langs/fr.json
+++ b/langs/fr.json
@@ -219,7 +219,7 @@
         "UG": "Ougandais",
         "UA": "Ukrainien",
         "AE": "Émirien",
-        "GB": "Britanique",
+        "GB": "Britannique",
         "US": "Américain",
         "UM": "Îles mineures éloignées des États-Unis",
         "UY": "Uruguayen",


### PR DESCRIPTION
See https://fr.wikipedia.org/wiki/Royaume-Uni or https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000019509867