### PR TITLE
Remove trailing spaces from CN

### DIFF
--- a/langs/fi.json
+++ b/langs/fi.json
@@ -48,7 +48,7 @@
     "CK": "uusiseelantilainen / cookinsaarelainen",
     "CL": "chileläinen",
     "CM": "kamerunilainen",
-    "CN": "kiinalainen  ",
+    "CN": "kiinalainen",
     "CO": "kolumbialainen",
     "CR": "costaricalainen",
     "CU": "kuubalainen",


### PR DESCRIPTION
Something I found out when proofreading the Finnish translations by @valstu

https://github.com/sourcecode911/i18n-nationality/pull/14