### PR TITLE
fix: update nl.json with right translation for a Dutch citizen

### DIFF
--- a/langs/nl.json
+++ b/langs/nl.json
@@ -145,7 +145,7 @@
         "NA": "Namibisch",
         "NR": "Nauruaans",
         "NP": "Nepalees",
-        "NL": "Nederlander",
+        "NL": "Nederlandse",
         "NC": "Nieuw-Caledonië",
         "NZ": "Nieuw-Zeelander",
         "NI": "Nicaraguaan",


### PR DESCRIPTION
We use this voor nationalities as stated in a passport. The right translation for a Dutch person is "Nederlandse". See also: https://www.rijksoverheid.nl/onderwerpen/privacy-en-persoonsgegevens/vraag-en-antwoord/waar-vind-ik-mijn-burgerservicenummer-bsn-op-mijn-paspoort