### PR TITLE
fix: typo in de.json

### DIFF
--- a/langs/de.json
+++ b/langs/de.json
@@ -164,7 +164,7 @@
         "PG": "Papua-Neuguienisch",
         "PY": "Paraguayisch",
         "PE": "Peruanisch",
-        "PH": "Philippinsch",
+        "PH": "Philippinisch",
         "PN": "Pitcairninseln",
         "PL": "Polnisch",
         "PT": "Portugiesisch",


### PR DESCRIPTION
- [x] fixes typo in German translation.